### PR TITLE
implement EGL_ANDROID_native_fence_sync

### DIFF
--- a/app/src/main/cpp/gui.cpp
+++ b/app/src/main/cpp/gui.cpp
@@ -110,3 +110,106 @@ Java_com_termux_gui_views_HardwareBufferSurfaceView_00024EGLImageKHR_00024Compan
     }
     eglImageTargetTexture2D.load()(GL_TEXTURE_EXTERNAL_OES, (GLeglImageOES) img);
 }
+
+static PFNEGLCREATESYNCKHRPROC  eglCreateSyncKHR   = nullptr;
+static PFNEGLWAITSYNCKHRPROC    eglWaitSyncKHR     = nullptr;
+static PFNEGLDESTROYSYNCKHRPROC eglDestroySyncKHR  = nullptr;
+
+static jfieldID g_field_descriptor       = nullptr;
+
+static jint native_sync(JNIEnv* env, jobject thiz, jobject fence) {
+    int          fd = EGL_NO_NATIVE_FENCE_FD_ANDROID;
+    EGLDisplay  dpy = EGL_NO_DISPLAY;
+    EGLSyncKHR sync = EGL_NO_SYNC_KHR;
+
+    fd = env->GetIntField(fence, g_field_descriptor);
+    dpy = eglGetCurrentDisplay();
+    if (dpy == EGL_NO_DISPLAY) {
+        goto error;
+    }
+    sync = eglCreateSyncKHR(
+            dpy,
+            EGL_SYNC_NATIVE_FENCE_ANDROID,
+            (EGLint[]){
+                EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fd,
+                EGL_NONE
+            });
+    if (sync == EGL_NO_SYNC_KHR) {
+        goto error;
+    }
+    if (eglWaitSyncKHR(dpy, sync, 0) != EGL_TRUE) {
+        goto error;
+    }
+    if (eglDestroySyncKHR(dpy, sync) != EGL_TRUE) {
+        goto error;
+    }
+    return 0;
+
+error:
+    if (fd != EGL_NO_NATIVE_FENCE_FD_ANDROID) {
+        close(fd);
+    }
+    return eglGetError();
+}
+
+static JNINativeMethod gMethods[] = {
+        {"nativeSync", "(Ljava/io/FileDescriptor;)I", (void*) native_sync},
+};
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    JNIEnv* env = nullptr;
+    jclass  clz = nullptr;
+    jclass  cfd = nullptr;
+
+    if (vm->GetEnv((void **) &env, JNI_VERSION_1_4) != JNI_OK) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get env");
+        goto error;
+    }
+
+    clz = env->FindClass("com/termux/gui/views/HardwareBufferSurfaceView$EGLSyncKHR$Companion");
+    if (clz == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get clz");
+        goto error;
+    }
+
+    if (env->RegisterNatives(clz, gMethods, sizeof(gMethods)/sizeof(gMethods[0])) < 0) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error register methods");
+        goto error;
+    }
+
+    eglCreateSyncKHR = (PFNEGLCREATESYNCKHRPROC) eglGetProcAddress("eglCreateSyncKHR");
+    if (eglCreateSyncKHR == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get eglCreateSyncKHR");
+        goto error;
+    }
+
+    eglWaitSyncKHR = (PFNEGLWAITSYNCKHRPROC) eglGetProcAddress("eglWaitSyncKHR");
+    if (eglWaitSyncKHR == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get eglWaitSyncKHR");
+        goto error;
+    }
+
+    eglDestroySyncKHR = (PFNEGLDESTROYSYNCKHRPROC) eglGetProcAddress("eglDestroySyncKHR");
+    if (eglDestroySyncKHR == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get eglDestroySyncKHR");
+        goto error;
+    }
+
+    cfd = env->FindClass("java/io/FileDescriptor");
+    if (cfd == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get FileDescriptor");
+        goto error;
+    }
+
+    g_field_descriptor = env->GetFieldID(cfd, "descriptor", "I");
+    if (g_field_descriptor == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error get field descriptor");
+        goto error;
+    }
+
+    return JNI_VERSION_1_4;
+
+error:
+    __android_log_print(ANDROID_LOG_ERROR, "JNI_OnLoad", "error load class EGLSyncKHR");
+    return -1;
+}

--- a/app/src/main/java/com/termux/gui/Logger.kt
+++ b/app/src/main/java/com/termux/gui/Logger.kt
@@ -1,6 +1,10 @@
 package com.termux.gui
 
 import android.util.Log
+import android.os.Environment
+import java.io.File
+import java.io.FileWriter
+import java.io.BufferedWriter
 
 /**
  * Global logging that's configured with the log level from the settings.
@@ -12,5 +16,20 @@ class Logger {
                 Log.i(tag, msg)
             }
         }
+
+        fun writeLog(msg: String) {
+            val path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).absolutePath
+            val file = File(path + "/log.txt")
+            if (!file.exists()) {
+                        file.createNewFile()
+                    }
+                    val fileWriter = FileWriter(file, true)
+                    val bufWriter = BufferedWriter(fileWriter)
+                    bufWriter.write(msg)
+                    bufWriter.newLine()
+                    bufWriter.close()
+                    fileWriter.close()
+}
+        
     }
 }

--- a/app/src/main/java/com/termux/gui/protocol/protobuf/ProtoUtils.kt
+++ b/app/src/main/java/com/termux/gui/protocol/protobuf/ProtoUtils.kt
@@ -48,6 +48,13 @@ class ProtoUtils {
             w.flush()
         }
 
+        fun recvFDs(s: LocalSocket): Array<FileDescriptor> {
+            return s.run {
+                inputStream.read()
+                getAncillaryFileDescriptors()
+            }
+        }
+
         fun unitToTypedValue(u: GUIProt0.Size.Unit): Int {
             return when (u) {
                 GUIProt0.Size.Unit.dp -> TypedValue.COMPLEX_UNIT_DIP

--- a/app/src/main/java/com/termux/gui/protocol/protobuf/v0/V0Proto.kt
+++ b/app/src/main/java/com/termux/gui/protocol/protobuf/v0/V0Proto.kt
@@ -158,7 +158,7 @@ class V0Proto(app: Context, private val eventQueue: LinkedBlockingQueue<Event>) 
 
                     Method.MethodCase.CREATEHARDWAREBUFFER -> handleBuffer.createHardwareBuffer(m.createHardwareBuffer)
                     Method.MethodCase.DESTROYHARDWAREBUFFER -> handleBuffer.destroyHardwareBuffer(m.destroyHardwareBuffer)
-                    Method.MethodCase.SETSURFACEBUFFER -> handleView.setSurfaceBuffer(m.setSurfaceBuffer)
+                    Method.MethodCase.SETSURFACEBUFFER -> handleView.setSurfaceBuffer(m.setSurfaceBuffer, main)
                     Method.MethodCase.SURFACECONFIG -> handleView.surfaceConfig(m.surfaceConfig)
                     
                     Method.MethodCase.CREATEREMOTELAYOUT -> handleRemote.createLayout(m.createRemoteLayout)

--- a/app/src/main/proto/GUIProt0.proto
+++ b/app/src/main/proto/GUIProt0.proto
@@ -2531,6 +2531,7 @@ gets centered horizontally in the SurfaceView, while the upper edge of the buffe
 message SurfaceViewSetBufferRequest {
   View v = 1;
   int32 buffer = 2;
+  bool sync = 3;
 }
 
 message SurfaceViewSetBufferResponse {


### PR DESCRIPTION
I add a new `bool` field `sync` to indicate whether `EGLSyncKHR` should be used.
```
message SurfaceViewSetBufferRequest {
  View v = 1;
  int32 buffer = 2;
  bool sync = 3;
}
```
If `true`, a `EGLSyncKHR` `fd` will be sent right after `SurfaceViewSetBufferRequest`, which will be parsed to `FileDescriptor` and passed to `EGLSyncKHR.sync(fence: FileDescriptor)` to wait for the sync signal.

Here is my test [file](https://github.com/termux/termux-gui/files/14402859/buffer_gl_sync.zip) and comparison
| ![gui-no-sync](https://github.com/termux/termux-gui/assets/6997430/cbed10ad-9a04-421f-8365-4c54d14ed288) | ![gui-sync](https://github.com/termux/termux-gui/assets/6997430/0672ac34-3379-4dae-8787-2c71ddd09c39) |
|:--:|:--:|
| *no sync* | *sync* |