### PR TITLE
Add protocol method to set a Termux RUN_COMMAND pending intent on a remote view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Used on Android 13 for the foreground service notification. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    
+    <!-- Used to run commands in the Termux app. -->
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
+
     <application
         android:name=".App"
         android:allowBackup="false"

--- a/app/src/main/java/com/termux/gui/protocol/shared/v0/DataClasses.kt
+++ b/app/src/main/java/com/termux/gui/protocol/shared/v0/DataClasses.kt
@@ -45,7 +45,15 @@ class DataClasses {
      */
     data class RemoteLayoutRepresentation(
         var root: RemoteViews?,
-        val viewCount: HashMap<KClass<*>, Int> = HashMap())
+        val viewCount: HashMap<KClass<*>, Int> = HashMap(),
+        var runCommand: RunCommand? = null
+    ) {
+        data class RunCommand(
+            val path: String,
+            val args: Array<String>,
+            val background: Boolean,
+        )
+    }
 
     /**
      * State of an Activity


### PR DESCRIPTION
This change allows a remote view in a widget to launch a command in Termux when clicked. This is useful to start a Termux program on-demand to update a widget, but let Termux and the program remain closed when the user is not interacting with the widget.

Add a new protocol method "setRemoteViewRunCommand", that accepts a command path parameter (which should be a full path to the executable), a command arguments parameter (which is a comma separated string), and a run in background parameter (which is a boolean). Store these in an optional RunCommand data class.

If this optional data class exists for a remote view ID when updating the widget layout, create a pending intent to invoke the Termux RUN_COMMAND service and set it on the widget root view.

Below is an example Python script that uses this protocol method to update a count every time the user taps on the widget.

```python
import sys
import termuxgui as tg

with tg.Connection() as c:
    wid = sys.argv[1]
    count = sys.argv[2]
    count += 1

    rv = tg.RemoteViews(c)
    c.send_msg({"method": "setRemoteViewRunCommand", "params:" {
        "rid": rv.rid,
        "path": "/data/data/com.termux/files/usr/bin/python",
        "args": f"widget.py, {wid}, {count}",
        "background", True
    }})

    tv = rv.addTextView()
    rv.setText(tv, f"count: {count}")
    rv.setBackgroundColor(tv, 0xffffffff)
    rv.updateWidget(wid)
```